### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Only Publish Minor
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/montumodi/sqs-bulk-loader/security/code-scanning/2](https://github.com/montumodi/sqs-bulk-loader/security/code-scanning/2)

To address this problem, we should add a `permissions` block to the workflow to limit GITHUB_TOKEN access to the least privilege necessary. The safest place is at the workflow root, but adding it at the job level is also acceptable. Since the job only checks out source and publishes to npm (and does not interact with PRs/issues or require write access to repository contents), it only needs `contents: read`. To implement this, add the following lines near the top of the workflow file, after the `name:` line and before `on:`. No other changes or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
